### PR TITLE
Update Typescript to v4

### DIFF
--- a/packages/autocomplete-library/package.json
+++ b/packages/autocomplete-library/package.json
@@ -50,7 +50,7 @@
         "rollup-plugin-typescript2": "^0.26.0",
         "shelljs": "^0.8.3",
         "ts-jest": "^25.1.2",
-        "typescript": "^3.7.3"
+        "typescript": "^4.1.6"
     },
     "dependencies": {
         "@netresearch/postdirekt-autocomplete-sdk": "^1.1.0"

--- a/packages/autocomplete-sdk/package.json
+++ b/packages/autocomplete-sdk/package.json
@@ -50,7 +50,7 @@
         "rollup-plugin-typescript2": "^0.26.0",
         "shelljs": "^0.8.3",
         "ts-jest": "^25.0",
-        "typescript": "^3.7.3"
+        "typescript": "^4.1.6"
     },
     "dependencies": {}
 }


### PR DESCRIPTION
With TypeScript v3, I got the following issue:

    $ yarn build
    yarn run v1.22.21
    $ tsc --build --force && rimraf dist &&  rollup -c rollup.config.esnext.js
    node_modules/@types/babel__traverse/index.d.ts:314:13 - error TS1110: Type expected.

    314         [k: `${string}|${string}`]: VisitNode<S, Node>;
                    ~~~

    node_modules/@types/babel__traverse/index.d.ts:314:34 - error TS1005: ';' expected.

    314         [k: `${string}|${string}`]: VisitNode<S, Node>;
                                         ~

    node_modules/@types/babel__traverse/index.d.ts:314:35 - error TS1128: Declaration or statement expected.

    314         [k: `${string}|${string}`]: VisitNode<S, Node>;
                                          ~

    node_modules/@types/babel__traverse/index.d.ts:314:55 - error TS1005: '(' expected.

    314         [k: `${string}|${string}`]: VisitNode<S, Node>;
                                                              ~

    node_modules/@types/babel__traverse/index.d.ts:315:5 - error TS1128: Declaration or statement expected.

    315     };
            ~

    node_modules/@types/lodash/common/object.d.ts:1025:21 - error TS1110: Type expected.

    1025         : K extends `${number}`
                             ~~~

    node_modules/@types/lodash/common/object.d.ts:1026:24 - error TS1005: ':' expected.

    1026             ? 'length' extends keyof T
                                ~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1026:38 - error TS1005: ';' expected.

    1026             ? 'length' extends keyof T
                                              ~

    node_modules/@types/lodash/common/object.d.ts:1027:26 - error TS1005: ':' expected.

    1027                 ? number extends T['length']
                                  ~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1028:30 - error TS1005: ':' expected.

    1028                     ? number extends keyof T
                                      ~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1028:44 - error TS1005: ';' expected.

    1028                     ? number extends keyof T
                                                    ~

    node_modules/@types/lodash/common/object.d.ts:1031:21 - error TS1128: Declaration or statement expected.

    1031                     : undefined
                             ~

    node_modules/@types/lodash/common/object.d.ts:1043:41 - error TS1110: Type expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                 ~~~

    node_modules/@types/lodash/common/object.d.ts:1043:50 - error TS1005: '}' expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                          ~~~~

    node_modules/@types/lodash/common/object.d.ts:1043:55 - error TS1128: Declaration or statement expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                               ~

    node_modules/@types/lodash/common/object.d.ts:1043:57 - error TS1005: ';' expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                                 ~

    node_modules/@types/lodash/common/object.d.ts:1043:64 - error TS1005: ';' expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                                        ~~~~~

    node_modules/@types/lodash/common/object.d.ts:1046:29 - error TS1005: ';' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                     ~

    node_modules/@types/lodash/common/object.d.ts:1046:30 - error TS1005: ';' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                      ~

    node_modules/@types/lodash/common/object.d.ts:1046:37 - error TS1005: ';' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                             ~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1046:48 - error TS1005: ',' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                                        ~

    node_modules/@types/lodash/common/object.d.ts:1046:55 - error TS1005: ',' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                                               ~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1053:26 - error TS1005: ';' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                  ~

    node_modules/@types/lodash/common/object.d.ts:1053:27 - error TS1005: ';' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                   ~

    node_modules/@types/lodash/common/object.d.ts:1053:34 - error TS1005: ';' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                          ~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1053:45 - error TS1005: ',' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                                     ~

    node_modules/@types/lodash/common/object.d.ts:1053:52 - error TS1005: ',' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                                            ~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1307:23 - error TS1005: ';' expected.

    1307          * Checks if `path` is a direct property of `object`.
                               ~~~~

    node_modules/@types/lodash/common/object.d.ts:1307:54 - error TS1005: ';' expected.

    1307          * Checks if `path` is a direct property of `object`.
                                                              ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1312:30 - error TS1005: ';' expected.

    1312          * @returns Returns `true` if `path` exists, else `false`.
                                      ~~~~

    node_modules/@types/lodash/common/object.d.ts:1312:40 - error TS1005: ';' expected.

    1312          * @returns Returns `true` if `path` exists, else `false`.
                                                ~~~~

    node_modules/@types/lodash/common/object.d.ts:1312:60 - error TS1005: ';' expected.

    1312          * @returns Returns `true` if `path` exists, else `false`.
                                                                    ~~~~~

    node_modules/@types/lodash/common/object.d.ts:1346:23 - error TS1005: ';' expected.

    1346          * Checks if `path` is a direct or inherited property of `object`.
                               ~~~~

    node_modules/@types/lodash/common/object.d.ts:1346:67 - error TS1005: ';' expected.

    1346          * Checks if `path` is a direct or inherited property of `object`.
                                                                           ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1351:30 - error TS1005: ';' expected.

    1351          * @returns Returns `true` if `path` exists, else `false`.
                                      ~~~~

    node_modules/@types/lodash/common/object.d.ts:1351:40 - error TS1005: ';' expected.

    1351          * @returns Returns `true` if `path` exists, else `false`.
                                                ~~~~

    node_modules/@types/lodash/common/object.d.ts:1351:60 - error TS1005: ';' expected.

    1351          * @returns Returns `true` if `path` exists, else `false`.
                                                                    ~~~~~

    node_modules/@types/lodash/common/object.d.ts:1751:16 - error TS1005: ';' expected.

    1751          * to `undefined`. Array and plain object properties are merged recursively.
                        ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1756:43 - error TS1005: ';' expected.

    1756          * **Note:** This method mutates `object`.
                                                   ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1761:30 - error TS1005: ';' expected.

    1761          * @returns Returns `object`.
                                      ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1842:33 - error TS1005: ';' expected.

    1842          * This method is like `_.merge` except that it accepts `customizer` which
                                         ~

    node_modules/@types/lodash/common/object.d.ts:1842:66 - error TS1005: ';' expected.

    1842          * This method is like `_.merge` except that it accepts `customizer` which
                                                                          ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1844:28 - error TS1005: ';' expected.

    1844          * properties. If `customizer` returns `undefined` merging is handled by the
                                    ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1844:49 - error TS1005: ';' expected.

    1844          * properties. If `customizer` returns `undefined` merging is handled by the
                                                         ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1845:33 - error TS1005: ';' expected.

    1845          * method instead. The `customizer` is invoked with seven arguments:
                                         ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1852:30 - error TS1005: ';' expected.

    1852          * @returns Returns `object`.
                                      ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1938:29 - error TS1005: ';' expected.

    1938          * The opposite of `_.pick`; this method creates an object composed of the
                                     ~

    node_modules/@types/lodash/common/object.d.ts:1939:56 - error TS1005: ';' expected.

    1939          * own and inherited enumerable properties of `object` that are not omitted.
                                                                ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2000:29 - error TS1005: ';' expected.

    2000          * The opposite of `_.pickBy`; this method creates an object composed of the
                                     ~

    node_modules/@types/lodash/common/object.d.ts:2001:56 - error TS1005: ';' expected.

    2001          * own and inherited enumerable properties of `object` that `predicate`
                                                                ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2001:70 - error TS1005: ';' expected.

    2001          * own and inherited enumerable properties of `object` that `predicate`
                                                                              ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2051:54 - error TS1005: ';' expected.

    2051          * Creates an object composed of the picked `object` properties.
                                                              ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2093:47 - error TS1005: ';' expected.

    2093          * Creates an object composed of the `object` properties `predicate` returns
                                                       ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2093:67 - error TS1005: ';' expected.

    2093          * Creates an object composed of the `object` properties `predicate` returns
                                                                           ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2443:33 - error TS1005: ';' expected.

    2443          * This method is like `_.update` except that it accepts `customizer` which is
                                         ~

    node_modules/@types/lodash/common/object.d.ts:2443:67 - error TS1005: ';' expected.

    2443          * This method is like `_.update` except that it accepts `customizer` which is
                                                                           ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2444:47 - error TS1005: ';' expected.

    2444          * invoked to produce the objects of `path`.  If `customizer` returns `undefined`
                                                       ~~~~

    node_modules/@types/lodash/common/object.d.ts:2444:59 - error TS1005: ';' expected.

    2444          * invoked to produce the objects of `path`.  If `customizer` returns `undefined`
                                                                   ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2444:80 - error TS1005: ';' expected.

    2444          * invoked to produce the objects of `path`.  If `customizer` returns `undefined`
                                                                                        ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2445:65 - error TS1005: ';' expected.

    2445          * path creation is handled by the method instead. The `customizer` is invoked
                                                                         ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2448:43 - error TS1005: ';' expected.

    2448          * **Note:** This method mutates `object`.
                                                   ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2456:30 - error TS1005: ';' expected.

    2456          * @returns Returns `object`.
                                      ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2581:1 - error TS1160: Unterminated template literal.

    2581 
         

    node_modules/@types/babel__traverse/index.d.ts:314:13 - error TS1110: Type expected.

    314         [k: `${string}|${string}`]: VisitNode<S, Node>;
                    ~~~

    node_modules/@types/babel__traverse/index.d.ts:314:34 - error TS1005: ';' expected.

    314         [k: `${string}|${string}`]: VisitNode<S, Node>;
                                         ~

    node_modules/@types/babel__traverse/index.d.ts:314:35 - error TS1128: Declaration or statement expected.

    314         [k: `${string}|${string}`]: VisitNode<S, Node>;
                                          ~

    node_modules/@types/babel__traverse/index.d.ts:314:55 - error TS1005: '(' expected.

    314         [k: `${string}|${string}`]: VisitNode<S, Node>;
                                                              ~

    node_modules/@types/babel__traverse/index.d.ts:315:5 - error TS1128: Declaration or statement expected.

    315     };
            ~

    node_modules/@types/lodash/common/object.d.ts:1025:21 - error TS1110: Type expected.

    1025         : K extends `${number}`
                             ~~~

    node_modules/@types/lodash/common/object.d.ts:1026:24 - error TS1005: ':' expected.

    1026             ? 'length' extends keyof T
                                ~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1026:38 - error TS1005: ';' expected.

    1026             ? 'length' extends keyof T
                                              ~

    node_modules/@types/lodash/common/object.d.ts:1027:26 - error TS1005: ':' expected.

    1027                 ? number extends T['length']
                                  ~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1028:30 - error TS1005: ':' expected.

    1028                     ? number extends keyof T
                                      ~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1028:44 - error TS1005: ';' expected.

    1028                     ? number extends keyof T
                                                    ~

    node_modules/@types/lodash/common/object.d.ts:1031:21 - error TS1128: Declaration or statement expected.

    1031                     : undefined
                             ~

    node_modules/@types/lodash/common/object.d.ts:1043:41 - error TS1110: Type expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                 ~~~

    node_modules/@types/lodash/common/object.d.ts:1043:50 - error TS1005: '}' expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                          ~~~~

    node_modules/@types/lodash/common/object.d.ts:1043:55 - error TS1128: Declaration or statement expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                               ~

    node_modules/@types/lodash/common/object.d.ts:1043:57 - error TS1005: ';' expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                                 ~

    node_modules/@types/lodash/common/object.d.ts:1043:64 - error TS1005: ';' expected.

    1043     type GetFieldType<T, P> = P extends `${infer Left}.${infer Right}`
                                                                        ~~~~~

    node_modules/@types/lodash/common/object.d.ts:1046:29 - error TS1005: ';' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                     ~

    node_modules/@types/lodash/common/object.d.ts:1046:30 - error TS1005: ';' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                      ~

    node_modules/@types/lodash/common/object.d.ts:1046:37 - error TS1005: ';' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                             ~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1046:48 - error TS1005: ',' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                                        ~

    node_modules/@types/lodash/common/object.d.ts:1046:55 - error TS1005: ',' expected.

    1046             : Left extends `${infer FieldKey}[${infer IndexKey}]`
                                                               ~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1053:26 - error TS1005: ';' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                  ~

    node_modules/@types/lodash/common/object.d.ts:1053:27 - error TS1005: ';' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                   ~

    node_modules/@types/lodash/common/object.d.ts:1053:34 - error TS1005: ';' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                          ~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1053:45 - error TS1005: ',' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                                     ~

    node_modules/@types/lodash/common/object.d.ts:1053:52 - error TS1005: ',' expected.

    1053             : P extends `${infer FieldKey}[${infer IndexKey}]`
                                                            ~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1307:23 - error TS1005: ';' expected.

    1307          * Checks if `path` is a direct property of `object`.
                               ~~~~

    node_modules/@types/lodash/common/object.d.ts:1307:54 - error TS1005: ';' expected.

    1307          * Checks if `path` is a direct property of `object`.
                                                              ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1312:30 - error TS1005: ';' expected.

    1312          * @returns Returns `true` if `path` exists, else `false`.
                                      ~~~~

    node_modules/@types/lodash/common/object.d.ts:1312:40 - error TS1005: ';' expected.

    1312          * @returns Returns `true` if `path` exists, else `false`.
                                                ~~~~

    node_modules/@types/lodash/common/object.d.ts:1312:60 - error TS1005: ';' expected.

    1312          * @returns Returns `true` if `path` exists, else `false`.
                                                                    ~~~~~

    node_modules/@types/lodash/common/object.d.ts:1346:23 - error TS1005: ';' expected.

    1346          * Checks if `path` is a direct or inherited property of `object`.
                               ~~~~

    node_modules/@types/lodash/common/object.d.ts:1346:67 - error TS1005: ';' expected.

    1346          * Checks if `path` is a direct or inherited property of `object`.
                                                                           ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1351:30 - error TS1005: ';' expected.

    1351          * @returns Returns `true` if `path` exists, else `false`.
                                      ~~~~

    node_modules/@types/lodash/common/object.d.ts:1351:40 - error TS1005: ';' expected.

    1351          * @returns Returns `true` if `path` exists, else `false`.
                                                ~~~~

    node_modules/@types/lodash/common/object.d.ts:1351:60 - error TS1005: ';' expected.

    1351          * @returns Returns `true` if `path` exists, else `false`.
                                                                    ~~~~~

    node_modules/@types/lodash/common/object.d.ts:1751:16 - error TS1005: ';' expected.

    1751          * to `undefined`. Array and plain object properties are merged recursively.
                        ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1756:43 - error TS1005: ';' expected.

    1756          * **Note:** This method mutates `object`.
                                                   ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1761:30 - error TS1005: ';' expected.

    1761          * @returns Returns `object`.
                                      ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1842:33 - error TS1005: ';' expected.

    1842          * This method is like `_.merge` except that it accepts `customizer` which
                                         ~

    node_modules/@types/lodash/common/object.d.ts:1842:66 - error TS1005: ';' expected.

    1842          * This method is like `_.merge` except that it accepts `customizer` which
                                                                          ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1844:28 - error TS1005: ';' expected.

    1844          * properties. If `customizer` returns `undefined` merging is handled by the
                                    ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1844:49 - error TS1005: ';' expected.

    1844          * properties. If `customizer` returns `undefined` merging is handled by the
                                                         ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1845:33 - error TS1005: ';' expected.

    1845          * method instead. The `customizer` is invoked with seven arguments:
                                         ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1852:30 - error TS1005: ';' expected.

    1852          * @returns Returns `object`.
                                      ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:1938:29 - error TS1005: ';' expected.

    1938          * The opposite of `_.pick`; this method creates an object composed of the
                                     ~

    node_modules/@types/lodash/common/object.d.ts:1939:56 - error TS1005: ';' expected.

    1939          * own and inherited enumerable properties of `object` that are not omitted.
                                                                ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2000:29 - error TS1005: ';' expected.

    2000          * The opposite of `_.pickBy`; this method creates an object composed of the
                                     ~

    node_modules/@types/lodash/common/object.d.ts:2001:56 - error TS1005: ';' expected.

    2001          * own and inherited enumerable properties of `object` that `predicate`
                                                                ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2001:70 - error TS1005: ';' expected.

    2001          * own and inherited enumerable properties of `object` that `predicate`
                                                                              ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2051:54 - error TS1005: ';' expected.

    2051          * Creates an object composed of the picked `object` properties.
                                                              ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2093:47 - error TS1005: ';' expected.

    2093          * Creates an object composed of the `object` properties `predicate` returns
                                                       ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2093:67 - error TS1005: ';' expected.

    2093          * Creates an object composed of the `object` properties `predicate` returns
                                                                           ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2443:33 - error TS1005: ';' expected.

    2443          * This method is like `_.update` except that it accepts `customizer` which is
                                         ~

    node_modules/@types/lodash/common/object.d.ts:2443:67 - error TS1005: ';' expected.

    2443          * This method is like `_.update` except that it accepts `customizer` which is
                                                                           ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2444:47 - error TS1005: ';' expected.

    2444          * invoked to produce the objects of `path`.  If `customizer` returns `undefined`
                                                       ~~~~

    node_modules/@types/lodash/common/object.d.ts:2444:59 - error TS1005: ';' expected.

    2444          * invoked to produce the objects of `path`.  If `customizer` returns `undefined`
                                                                   ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2444:80 - error TS1005: ';' expected.

    2444          * invoked to produce the objects of `path`.  If `customizer` returns `undefined`
                                                                                        ~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2445:65 - error TS1005: ';' expected.

    2445          * path creation is handled by the method instead. The `customizer` is invoked
                                                                         ~~~~~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2448:43 - error TS1005: ';' expected.

    2448          * **Note:** This method mutates `object`.
                                                   ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2456:30 - error TS1005: ';' expected.

    2456          * @returns Returns `object`.
                                      ~~~~~~

    node_modules/@types/lodash/common/object.d.ts:2581:1 - error TS1160: Unterminated template literal.

    2581 
         


    Found 126 errors.

With TypeScript v4, it works. I also verified that:

1. `yarn test` does not report any issues.
2. The generated `packages/autocomplete-library/dist/browser/postdirekt-autocomplete-lib.min.js` is the same.

I did not update to v5, because this leads to other issues :D