### PR TITLE
Add source element to event

### DIFF
--- a/packages/autocomplete-library/src/model/autocomplete-handler.ts
+++ b/packages/autocomplete-library/src/model/autocomplete-handler.ts
@@ -180,7 +180,12 @@ export default class AddressAutocomplete {
             document.dispatchEvent(
                 new CustomEvent(
                     'autocomplete:suggestions-retrieve',
-                    { detail: { suggestions: this.addressSuggestions.suggestions } },
+                    {
+                        detail: {
+                            suggestions: this.addressSuggestions.suggestions,
+                            sourceElement: currentField,
+                        },
+                    },
                 ),
             );
 


### PR DESCRIPTION
@powli, would you mind also having a look at that one? It only adds new data to an existing event, so it should not break anything at all. It is necessary in order to position suggestions properly when the suggestion rendering is done manually.