### PR TITLE
docs: update README to reflect current tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To download Node.js visit https://nodejs.org/en/download/.
 
 _NOTE: You can use a tool like [`NVM`](https://github.com/nvm-sh/nvm)
 or [`N`](https://github.com/tj/n) to install and manage multiple node versions.
-With NVM, run `nvm use` in the repo root to automatically switch to the correct version._
+With NVM, run `nvm install` in the repo root to automatically install and switch to the correct version._
 
 #### Yarn
 
@@ -29,7 +29,7 @@ Yarn will be automatically resolved from the `packageManager` field in `package.
 
 #### Verify Prerequisites
 
-You can verify your setup by running the following commands in your terminal:
+You can verify your setup by running the following commands in your terminal at the root of the repo:
 
 ```bash
 node -v

--- a/README.md
+++ b/README.md
@@ -1,54 +1,57 @@
-# Postdirekt Autocomplete Metapackage
+# Postdirekt Autocomplete Monorepo
 
-This package is a monorepo for the _@netresearch/postdirekt-autocomplete-library_ and _@netresearch/postdirekt-autocomplete-sdk_ npm package.
-## SDK Developer and Contribution Workflow
+This monorepo contains the _@netresearch/postdirekt-autocomplete-library_ and _@netresearch/postdirekt-autocomplete-sdk_ npm packages.
+
+## Developer and Contribution Workflow
 
 ### Prerequisites
 
 #### Node.js
 
 Before you can start working on the Autocomplete monorepo, you need to have Node.js
-installed on your machine. The currently supported versions are `10.0.0` or greater.
+installed on your machine. The required version is pinned in `.nvmrc` (currently Node 22).
 
 To download Node.js visit https://nodejs.org/en/download/.
 
-_NOTE: You can use a tool like [`NVM`](https://github.com/creationix/nvm)
-or [`N`](https://github.com/tj/n) to install and manage multiple node versions_
+_NOTE: You can use a tool like [`NVM`](https://github.com/nvm-sh/nvm)
+or [`N`](https://github.com/tj/n) to install and manage multiple node versions.
+With NVM, run `nvm use` in the repo root to automatically switch to the correct version._
 
 #### Yarn
 
-In addition to Node.js we use `yarn` to facilitate multi package development.
+This project uses [Yarn 4](https://yarnpkg.com/) via Node.js corepack. Enable it with:
 
-To install `yarn` follow the instructions listed on their website:
-https://yarnpkg.com/en/docs/install
+```bash
+corepack enable
+```
+
+Yarn will be automatically resolved from the `packageManager` field in `package.json` -- no separate installation needed.
 
 #### Verify Prerequisites
 
 You can verify your setup by running the following commands in your terminal:
 
 ```bash
-$ node -v
-$ yarn -v
+node -v
+yarn -v
 ```
 
-Your Node.js version should be `10.0.0` or greater, your `yarn` version should
-be `1.0.0` or greater,
+Your Node.js version should match `.nvmrc`, and `yarn -v` should show `4.x`.
 
 ### Install Dependencies
 
-Once you have Node.js and `yarn` installed on your machine and have validated
-that you are running the proper version, you can set up the development environment
+Once you have Node.js and corepack enabled, set up the development environment
 by running the following at the root of the repo:
 
 ```bash
-$ yarn
+yarn
 ```
 
 Once you have installed all the dependencies, you can build both packages by
-running the following command the root of the repo:
+running the following command at the root of the repo:
 
 ```bash
-$ yarn build
+yarn build
 ```
 
 ## Packages
@@ -61,36 +64,34 @@ See [Readme](packages/autocomplete-sdk/README.md).
 
 ### packages/autocomplete-library
 
-This folder contains the _@netresearch/postdirekt-autocomplete-library, responsible for registering input listeners on given input fields (street address, city and postcode) and fetching address suggestions from the Autocomplete API via the autocomplete-sdk package.
+This folder contains the _@netresearch/postdirekt-autocomplete-library_, responsible for registering input listeners on given input fields (street address, city and postcode) and fetching address suggestions from the Autocomplete API via the autocomplete-sdk package.
 
 See [Readme](packages/autocomplete-library/README.md).
 
 ## Testing the packages
 
-### Running the Tests
-
-You can run the tests with the command
+You can run the tests with:
 
 ```bash
-$ yarn test
+yarn test
 ```
 
-To run the linter, do
+To run the linter:
 
 ```bash
-$ yarn lint
+yarn lint
 ```
 
 ## Building the packages
 
-You can build ES2017 compatible artifacts (this is what's published on npm) with
+You can build ES2017 compatible artifacts (this is what's published on npm) with:
 
 ```bash
-$ yarn build
+yarn build
 ```
 
-You can also build ES5 compatible artifacts (output in `<rootDir>/dist`) with
+You can also build ES5 compatible artifacts (output in `<rootDir>/dist`) with:
 
 ```bash
-$ yarn build:es5
+yarn build:es5
 ```


### PR DESCRIPTION
## Summary
- Updates Node.js requirement from 10 to 22 (matching `.nvmrc`)
- Replaces Yarn Classic install instructions with Yarn 4 via corepack
- Fixes stale NVM link (`creationix` → `nvm-sh`)
- Fixes missing closing backtick on autocomplete-library italic
- Removes `$` prompt prefixes from code blocks
- Renames title from "Metapackage" to "Monorepo"

## Test plan
- [ ] Verify rendered README on GitHub looks correct