### PR TITLE
fix(deps): bump js-yaml to 4.3.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3969,13 +3969,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes the open Dependabot alert on \`yarn.lock\` — js-yaml 4.1.1, vulnerable to [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) and [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) (quadratic-complexity DoS via YAML merge-key chains). Reached through `@eslint/eslintrc`.

Produced by `yarn up -R js-yaml`; the lockfile diff is the single js-yaml entry.

## Verification

`yarn lint` clean; `yarn test` — 9 suites, 21 tests passed.